### PR TITLE
feat: document metrics endpoint

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -19,6 +19,17 @@ api:
   # This can also be set via the API_LISTEN_PORT environment variable
   port: 8090
 
+metrics:
+  # Listen address for the metrics endpoint
+  #
+  # This can also be set via the METRICS_LISTEN_ADDRESS environment variable
+  address:
+
+  # Listen port for the metrics endpoint
+  #
+  # This can also be set via the METRICS_LISTEN_PORT environment variable
+  port: 8081
+
 # The debug endpoint provides access to pprof for debugging purposes. This is
 # disabled by default, but it can be enabled by setting the port to a non-zero
 # value

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -66,8 +66,8 @@ func Start(cfg *config.Config) error {
 	go func() {
 		// TODO: return error if we cannot initialize metrics
 		_ = metricsRouter.Run(fmt.Sprintf("%s:%d",
-			cfg.Metrics.MetricsAddress,
-			cfg.Metrics.MetricsPort))
+			cfg.Metrics.ListenAddress,
+			cfg.Metrics.ListenPort))
 	}()
 
 	// Configure API routes

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -66,8 +66,8 @@ func Start(cfg *config.Config) error {
 	go func() {
 		// TODO: return error if we cannot initialize metrics
 		_ = metricsRouter.Run(fmt.Sprintf("%s:%d",
-			cfg.Api.MetricsAddress,
-			cfg.Api.MetricsPort))
+			cfg.Metrics.MetricsAddress,
+			cfg.Metrics.MetricsPort))
 	}()
 
 	// Configure API routes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -36,8 +36,8 @@ type DebugConfig struct {
 }
 
 type MetricsConfig struct {
-	MetricsAddress string `yaml:"metricsAddress" envconfig:"METRICS_LISTEN_ADDRESS"`
-	MetricsPort    uint   `yaml:"metricsPort" envconfig:"METRICS_LISTEN_PORT"`
+	ListenAddress string `yaml:"address" envconfig:"METRICS_LISTEN_ADDRESS"`
+	ListenPort    uint   `yaml:"port" envconfig:"METRICS_LISTEN_PORT"`
 }
 
 type NodeConfig struct {
@@ -62,8 +62,8 @@ var globalConfig = &Config{
 		ListenPort:    0,
 	},
 	Metrics: MetricsConfig{
-		MetricsAddress: "",
-		MetricsPort:    8081,
+		ListenAddress: "",
+		ListenPort:    8081,
 	},
 	Node: NodeConfig{
 		Network:    "mainnet",

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -16,6 +16,7 @@ const (
 type Config struct {
 	Logging LoggingConfig `yaml:"logging"`
 	Api     ApiConfig     `yaml:"api"`
+	Metrics MetricsConfig `yaml:"metrics"`
 	Debug   DebugConfig   `yaml:"debug"`
 	Node    NodeConfig    `yaml:"node"`
 }
@@ -27,13 +28,16 @@ type LoggingConfig struct {
 type ApiConfig struct {
 	ListenAddress  string `yaml:"address" envconfig:"API_LISTEN_ADDRESS"`
 	ListenPort     uint   `yaml:"port" envconfig:"API_LISTEN_PORT"`
-	MetricsAddress string `yaml:"metricsAddress" envconfig:"METRICS_LISTEN_ADDRESS"`
-	MetricsPort    uint   `yaml:"metricsPort" envconfig:"METRICS_LISTEN_PORT"`
 }
 
 type DebugConfig struct {
 	ListenAddress string `yaml:"address" envconfig:"DEBUG_ADDRESS"`
 	ListenPort    uint   `yaml:"port" envconfig:"DEBUG_PORT"`
+}
+
+type MetricsConfig struct {
+	MetricsAddress string `yaml:"metricsAddress" envconfig:"METRICS_LISTEN_ADDRESS"`
+	MetricsPort    uint   `yaml:"metricsPort" envconfig:"METRICS_LISTEN_PORT"`
 }
 
 type NodeConfig struct {
@@ -52,12 +56,14 @@ var globalConfig = &Config{
 	Api: ApiConfig{
 		ListenAddress:  "",
 		ListenPort:     8090,
-		MetricsAddress: "",
-		MetricsPort:    8081,
 	},
 	Debug: DebugConfig{
 		ListenAddress: "localhost",
 		ListenPort:    0,
+	},
+	Metrics: MetricsConfig{
+		MetricsAddress: "",
+		MetricsPort:    8081,
 	},
 	Node: NodeConfig{
 		Network:    "mainnet",


### PR DESCRIPTION
Document metrics endpoint in `config.yml.example` and update the YAML
based configuration to its own top-level key in the configuration file
to match the `debug` implementation.

Fixes #15

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>