### PR TITLE
feat: update swagger and add iohk copy

### DIFF
--- a/docs/iohk.yaml
+++ b/docs/iohk.yaml
@@ -1,0 +1,56 @@
+swagger: '2.0'
+schemes: ["http"]
+host: localhost
+basePath: /
+info:
+  title: cardano-submit-api
+  version: 3.1.0
+  license:
+    name: Apache-2.0
+    url: https://github.com/input-output-hk/cardano-rest/blob/master/submit-api/LICENSE
+  description: |
+    <p align="right"><img style="position: relative; top: -10em; margin-bottom: -12em;" width="20%" src="https://cardanodocs.com/img/cardano.png"></img></p>
+
+x-tagGroups: []
+
+definitions: {}
+
+paths:
+  /api/submit/tx:
+    post:
+      operationId: postTransaction
+      summary: Submit Tx
+      description: Submit an already serialized transaction to the network.
+      parameters:
+        - in: header
+          name: Content-Type
+          required: true
+          type: string
+          enum: ["application/cbor"]
+
+      x-code-samples:
+        - lang: "Shell"
+          label: "cURL"
+          source: |
+            # Assuming `data` is a raw binary serialized transaction on the file-system.
+            curl -X POST \
+                --header "Content-Type: application/cbor" \
+                --data-binary @data http://localhost:8101/api/submit/tx
+      produces:
+        - "application/json"
+      responses:
+        202:
+          description: Ok
+          schema:
+            description: The transaction id.
+            type: string
+            format: hex
+            minLength: 64
+            maxLength: 64
+            example: 92bcd06b25dfbd89b578d536b4d3b7dd269b7c2aa206ed518012cffe0444d67f
+
+        400:
+          description: Bad Request
+          schema:
+            type: string
+            description: An error message.

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -1,6 +1,10 @@
-basePath: /
+swagger: "2.0"
+schemes: ["http"]
 host: localhost:8090
+basePath: /
 info:
+  title: go-cardano-submit-api
+  version: 3.1.0
   contact:
     email: support@cloudstruct.net
     name: CloudStruct
@@ -9,11 +13,10 @@ info:
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  title: go-cardano-submit-api
-  version: 3.1.0
 paths:
   /api/submit/tx:
     post:
+      summary: Submit Tx
       description: Submit an already serialized transaction to the network.
       parameters:
       - description: Content type
@@ -38,7 +41,3 @@ paths:
           description: Server Error
           schema:
             type: string
-      summary: Submit Tx
-schemes:
-- http
-swagger: "2.0"


### PR DESCRIPTION
Manually update the swagger.yaml ordering a bit to make it align with
the upstream version of the file, which is imported as `iohk.yaml` to
allow for easy comparison.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>