### PR TITLE
feat: rename TCP options for cardano-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ within the application.
 
 Cardano node configuration:
 `CARDANO_NETWORK` - Use a named Cardano network (default: mainnet)
-`CARDANO_NODE_ADDRESS` - Address to Cardano node NtC via TCP (default: unset)
-`CARDANO_NODE_PORT` - Port to Cardano node NtC via TCP (default: unset)
 `CARDANO_NODE_NETWORK_MAGIC` - Cardano network magic (default: automatically determined from named network)
 `CARDANO_NODE_SOCKET_PATH` - Socket path to Cardano node NtC via UNIX socket (default: /node-ipc/node.socket)
+`CARDANO_NODE_SOCKET_TCP_HOST` - Address to Cardano node NtC via TCP (default: unset)
+`CARDANO_NODE_SOCKET_TCP_PORT` - Port to Cardano node NtC via TCP (default: unset)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,8 +39,8 @@ type MetricsConfig struct {
 type NodeConfig struct {
 	Network      string `yaml:"network" envconfig:"CARDANO_NETWORK"`
 	NetworkMagic uint32 `yaml:"networkMagic" envconfig:"CARDANO_NODE_NETWORK_MAGIC"`
-	Address      string `yaml:"address" envconfig:"CARDANO_NODE_ADDRESS"`
-	Port         uint   `yaml:"port" envconfig:"CARDANO_NODE_PORT"`
+	Address      string `yaml:"address" envconfig:"CARDANO_NODE_SOCKET_TCP_HOST"`
+	Port         uint   `yaml:"port" envconfig:"CARDANO_NODE_SOCKET_TCP_PORT"`
 	SocketPath   string `yaml:"socketPath" envconfig:"CARDANO_NODE_SOCKET_PATH"`
 }
 


### PR DESCRIPTION
Update the environment variable names used to connect to the
cardano-node NtC socket using TCP.

Signed-off-by: Chris Gianelloni <cgianelloni@cloudstruct.net>