### PR TITLE
Add build and publish of binaries to github-workflows

### DIFF
--- a/.github/workflows/publish-binaries.yml
+++ b/.github/workflows/publish-binaries.yml
@@ -1,0 +1,33 @@
+name: publish-binaries
+
+on:
+  release:
+    types: [created]
+
+concurrency: ${{ github.ref }}
+
+env:
+  BIN_NAME: cardano-submit-api
+
+jobs:
+  release:
+    strategy:
+      matrix:
+        # build and publish in parallel:
+        # linux/386, linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, darwin/386
+        goos: [linux, darwin]
+        goarch: ["386", amd64, arm64]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: wangyoucao577/go-release-action@v1.34
+        with:
+          binary_name: ${{ env.BIN_NAME }}
+          build_command: 'make build'
+          compress_assets: OFF
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          goarch: ${{ matrix.goarch }}
+          goos: ${{ matrix.goos }}
+          goversion: 1.18
+          md5sum: FALSE
+          sha256sum: TRUE

--- a/.github/workflows/publish-docker-images.yml
+++ b/.github/workflows/publish-docker-images.yml
@@ -1,4 +1,4 @@
-name: publish
+name: publish-docker-images
 
 on:
   push:


### PR DESCRIPTION
- Add build and publish of binaries to github-workflows
Fixes #44 

Testing can be seen @ 
https://github.com/cloudstruct/go-cardano-submit-api/actions/runs/3735143156/jobs/6338123546

Failed on windows, but I removed windows anyway because I don't think there is any intention to support that?